### PR TITLE
redraw whenever content changes

### DIFF
--- a/library/src/main/java/jp/shts/android/library/TriangleLabelView.java
+++ b/library/src/main/java/jp/shts/android/library/TriangleLabelView.java
@@ -165,6 +165,7 @@ public class TriangleLabelView extends View {
 
     public void setLabelCenterPadding(float dp) {
         centerPadding = dp2px(dp);
+        relayout();
     }
 
     public float getLabelCenterPadding() {
@@ -173,6 +174,7 @@ public class TriangleLabelView extends View {
 
     public void setLabelBottomPadding(float dp) {
         bottomPadding = dp2px(dp);
+        relayout();
     }
 
     public float getLabelBottomPadding() {
@@ -182,11 +184,13 @@ public class TriangleLabelView extends View {
     public void setPrimaryText(String text) {
         primary.text = text;
         primary.resetStatus();
+        relayout();
     }
 
     public void setPrimaryText(@StringRes int textRes) {
         primary.text = getContext().getString(textRes);
         primary.resetStatus();
+        relayout();
     }
 
     public String getPrimaryText() {
@@ -196,11 +200,13 @@ public class TriangleLabelView extends View {
     public void setSecondaryText(String smallText) {
         secondary.text = smallText;
         secondary.resetStatus();
+        relayout();
     }
 
     public void setSecondaryText(@StringRes int textRes) {
         secondary.text = getContext().getString(textRes);
         secondary.resetStatus();
+        relayout();
     }
 
     public String getSecondaryText() {
@@ -211,32 +217,38 @@ public class TriangleLabelView extends View {
         primary.color = color;
         primary.initPaint();
         primary.resetStatus();
+        relayout();
     }
 
     public void setPrimaryTextColorResource(@ColorRes int colorResource) {
         primary.color = ContextCompat.getColor(getContext(), colorResource);
         primary.initPaint();
         primary.resetStatus();
+        relayout();
     }
 
     public void setSecondaryTextColor(@ColorInt int color) {
         secondary.color = color;
         secondary.initPaint();
         secondary.resetStatus();
+        relayout();
     }
 
     public void setSecondaryTextColorResource(@ColorRes int colorResource) {
         secondary.color = ContextCompat.getColor(getContext(), colorResource);
         secondary.initPaint();
         secondary.resetStatus();
+        relayout();
     }
 
     public void setPrimaryTextSize(float sp) {
         primary.size = sp2px(sp);
+        relayout();
     }
 
     public void setSecondaryTextSize(float sp) {
         secondary.size = sp2px(sp);
+        relayout();
     }
 
     public float getPrimaryTextSize() {
@@ -250,11 +262,13 @@ public class TriangleLabelView extends View {
     public void setTriangleBackgroundColor(@ColorInt int color) {
         backGroundColor = color;
         trianglePaint.setColor(backGroundColor);
+        relayout();
     }
 
     public void setTriangleBackgroundColorResource(@ColorRes int colorResource) {
         backGroundColor = ContextCompat.getColor(getContext(), colorResource);
         trianglePaint.setColor(backGroundColor);
+        relayout();
     }
 
     public int getTriangleBackGroundColor() {
@@ -263,6 +277,7 @@ public class TriangleLabelView extends View {
 
     public void setCorner(Corner corner) {
         this.corner = corner;
+        relayout();
     }
 
     public Corner getCorner() {
@@ -339,4 +354,11 @@ public class TriangleLabelView extends View {
         return spValue * scale;
     }
 
+    /**
+     * Should be called whenever what we're displaying could have changed.
+     */
+    private void relayout() {
+        invalidate();
+        requestLayout();
+    }
 }


### PR DESCRIPTION
I believe that TriangleLabelView needs to explicitly invalidate and request a new layout whenever content changes.

In version 1.0.0 it does not do this and it can result in this problem if a user scrolls back and forth (the numbers in the center of each square should match the number in the TriangleLabelView but they do not)

![2016-03-31 19 09 19](https://cloud.githubusercontent.com/assets/5216560/14222069/658d2c8a-f83a-11e5-9958-c647a27eb5da.png)

In this PR every time a property of the view changes the content is invalidated and a new layout is requested.  (See https://developer.android.com/training/custom-views/create-view.html#addprop for more information)

Thanks for the great library!