### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add the dependency
 
 ```groovy
 	dependencies {
-	        compile 'com.github.shts:TriangleLabelView:1.1.2'
+	        implementation 'com.github.shts:TriangleLabelView:1.1.2'
 	}
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.